### PR TITLE
fix: ignore empty custom reasons

### DIFF
--- a/barricade/schemas.py
+++ b/barricade/schemas.py
@@ -392,6 +392,14 @@ class ReportSubmissionData(BaseModel):
     body: str
     attachment_urls: list[str] = Field(alias="attachmentUrls")
 
+    @field_validator("reasons")
+    @classmethod
+    def drop_empty_reasons(cls, reasons: list[str]) -> list[str]:
+        """
+        Filter out empty/whitespace-only reasons so we don't treat them as custom reasons.
+        """
+        return [reason.strip() for reason in reasons if reason and reason.strip()]
+
 class ReportSubmission(BaseModel):
     id: str
     timestamp: datetime

--- a/tests/test_submission_reasons.py
+++ b/tests/test_submission_reasons.py
@@ -1,0 +1,50 @@
+import unittest
+
+from barricade.enums import ReportReasonFlag
+from barricade.schemas import ReportSubmissionData
+
+
+class ReportSubmissionReasonsTest(unittest.TestCase):
+    def setUp(self):
+        self.base_payload = {
+            "token": "token",
+            "players": [
+                {
+                    "playerId": "123",
+                    "playerName": "Test Player",
+                    "bmRconUrl": None,
+                }
+            ],
+            "body": "Test body",
+            "attachmentUrls": [],
+        }
+
+    def test_empty_other_reason_removed(self):
+        payload = {
+            **self.base_payload,
+            "reasons": ["Toxicity / Harassment", ""],
+        }
+
+        submission = ReportSubmissionData.model_validate(payload)
+        self.assertEqual(submission.reasons, ["Toxicity / Harassment"])
+
+        flag, custom = ReportReasonFlag.from_list(submission.reasons)
+        self.assertEqual(flag, ReportReasonFlag.TOXICITY_HARASSMENT)
+        self.assertIsNone(custom)
+
+    def test_whitespace_only_reason_removed(self):
+        payload = {
+            **self.base_payload,
+            "reasons": ["   "],
+        }
+
+        submission = ReportSubmissionData.model_validate(payload)
+        self.assertEqual(submission.reasons, [])
+
+        flag, custom = ReportReasonFlag.from_list(submission.reasons)
+        self.assertEqual(flag, ReportReasonFlag(0))
+        self.assertIsNone(custom)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip empty/whitespace-only reasons from submissions so they are not treated as custom reasons
- add a test covering empty and whitespace-only "Other" inputs

## Rationale
- avoid sending empty strings in reasons, which causes API errors for empty "Other..." fields (Fixes #37)

## Changes
- add a reasons validator in ReportSubmissionData to drop empty entries
- add unittest to ensure empty/whitespace reasons are removed and flags computed correctly

## Test Plan
- tests added for CI

Fixes #37 